### PR TITLE
fix: ginkgo install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,7 @@ ginkgo:
 test: format ginkgo
 
 dep:
-		go get github.com/onsi/ginkgo/ginkgo
-		go get github.com/onsi/gomega
+		go install github.com/onsi/ginkgo/ginkgo@latest
 
 ci: ginkgo
 


### PR DESCRIPTION
- in go 1.18,  is no longer the correct way to install go command line util, we need to do  instead
(see: https://golang.org/doc/go-get-install-deprecation)
- remove unneccesary gomega install (gomega is already in go.mod, no need to install it separately)

Co-authored-by: Peter Chen <peterch@vmware.com>