### PR TITLE
add CGO_ENABLED=0 to all builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ build:
 
 build_all:
 		mkdir -p build
-		GOOS=darwin GOARCH=arm64 go build $(GOFLAGS) -o $(BUILD_DEST)-darwin-arm64
-		GOOS=darwin GOARCH=amd64 go build $(GOFLAGS) -o $(BUILD_DEST)-darwin-amd64
-		GOOS=linux GOARCH=amd64 go build $(GOFLAGS) -o $(BUILD_DEST)-linux-amd64
-		GOOS=windows GOARCH=amd64 go build $(GOFLAGS) -o $(BUILD_DEST)-windows-amd64
+		CGO_ENABLE=0 GOOS=darwin GOARCH=arm64 go build $(GOFLAGS) -o $(BUILD_DEST)-darwin-arm64
+		CGO_ENABLE=0 GOOS=darwin GOARCH=amd64 go build $(GOFLAGS) -o $(BUILD_DEST)-darwin-amd64
+		CGO_ENABLE=0 GOOS=linux GOARCH=amd64 go build $(GOFLAGS) -o $(BUILD_DEST)-linux-amd64
+		CGO_ENABLE=0 GOOS=windows GOARCH=amd64 go build $(GOFLAGS) -o $(BUILD_DEST)-windows-amd64
 
 install:
 		rm -rf $(INSTALL_DEST)


### PR DESCRIPTION
I do not have the ability to test this on Windows.
Fixes #149 