### PR TITLE
fix: Updating CGO_ENABLED typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ build:
 
 build_all:
 		mkdir -p build
-		CGO_ENABLE=0 GOOS=darwin GOARCH=arm64 go build $(GOFLAGS) -o $(BUILD_DEST)-darwin-arm64
-		CGO_ENABLE=0 GOOS=darwin GOARCH=amd64 go build $(GOFLAGS) -o $(BUILD_DEST)-darwin-amd64
-		CGO_ENABLE=0 GOOS=linux GOARCH=amd64 go build $(GOFLAGS) -o $(BUILD_DEST)-linux-amd64
-		CGO_ENABLE=0 GOOS=windows GOARCH=amd64 go build $(GOFLAGS) -o $(BUILD_DEST)-windows-amd64
+		CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(GOFLAGS) -o $(BUILD_DEST)-darwin-arm64
+		CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build $(GOFLAGS) -o $(BUILD_DEST)-darwin-amd64
+		CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(GOFLAGS) -o $(BUILD_DEST)-linux-amd64
+		CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(GOFLAGS) -o $(BUILD_DEST)-windows-amd64
 
 install:
 		rm -rf $(INSTALL_DEST)


### PR DESCRIPTION
Fixing CGO_ENABLED to have the missing d on the end.