### PR TITLE
Update Dependabot for go-uaa, updates deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       time: "11:00"
     allow:
       - dependency-type: "all"
+    cooldown:
+      default-days: 3
+      exclude:
+        - "github.com/cloudfoundry-community/go-uaa"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module code.cloudfoundry.org/uaa-cli
 
-go 1.25.0
+go 1.26.0
 
 require (
-	github.com/cloudfoundry-community/go-uaa v0.4.2
+	github.com/cloudfoundry-community/go-uaa v0.5.0
 	github.com/fatih/color v1.19.0
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/onsi/ginkgo/v2 v2.32.1
@@ -24,7 +24,7 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3 // indirect
+	github.com/google/pprof v0.0.0-20260825171938-4d453200e7d9 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudfoundry-community/go-uaa v0.4.2 h1:97mh++pSzsQecGARYwO6cS8l4lvStnTCZbC8sQ64SCA=
 github.com/cloudfoundry-community/go-uaa v0.4.2/go.mod h1:xjzM0WoAXgeLH8uG+DVj3gkmaYgBug8jJACghKyAVko=
+github.com/cloudfoundry-community/go-uaa v0.5.0 h1:j+9Czv6b4HUoEYwVZ2/fUzBoNaEFUeai/5r1nq5rku4=
+github.com/cloudfoundry-community/go-uaa v0.5.0/go.mod h1:biXSi4yoWUVnnWxE208bLMoyzuspYxToUZtktasl6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -35,6 +37,8 @@ github.com/google/pprof v0.0.0-20260507013755-92041b743c96 h1:YDDnaZ9afWajDboPMt
 github.com/google/pprof v0.0.0-20260507013755-92041b743c96/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3 h1:LMLX+LgTNWpfvCBdFebv6EsYotImrt/Ppc5cXIriCSo=
 github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3/go.mod h1:jl5iWTm0/hd5PjEYEOuwAJ57L/CibdZfrqZ5XA5GrCk=
+github.com/google/pprof v0.0.0-20260825171938-4d453200e7d9 h1:dl4UZiszMU+NKHirOiCKTC+hRuNAQ0moHPxSg6WcU1o=
+github.com/google/pprof v0.0.0-20260825171938-4d453200e7d9/go.mod h1:jl5iWTm0/hd5PjEYEOuwAJ57L/CibdZfrqZ5XA5GrCk=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=

--- a/integration/clients_test.go
+++ b/integration/clients_test.go
@@ -16,12 +16,11 @@ var _ = Describe("clients", Ordered, func() {
 		run("delete-client", clientID)
 	})
 
-	PIt("lists clients, including the legacy string-typed additionalInformation clients seeded by scripts/boot/uaa.yml", func() {
+	It("lists clients, including the legacy string-typed additionalInformation clients seeded by scripts/boot/uaa.yml", func() {
 		// login, client_federated_jwt_trust, client_with_allowpublic_and_jwks_uri_trust,
 		// and oauth_showcase_saml2_bearer are all seeded with allowpublic/autoapprove as
 		// YAML strings, which UAA stores verbatim and serializes back as JSON strings
 		// rather than booleans -- the exact shape that broke `uaa list-clients` originally.
-		// Un-pend once cloudfoundry-community/go-uaa#175 is released and go.mod is bumped.
 		session := runOK("list-clients")
 		assertValidJSON(session)
 		Expect(string(session.Out.Contents())).To(ContainSubstring("client_federated_jwt_trust"))

--- a/integration/users_test.go
+++ b/integration/users_test.go
@@ -39,13 +39,7 @@ var _ = Describe("users", Ordered, func() {
 		runOK("activate-user", username)
 	})
 
-	PIt("unlocks the user", func() {
-		// PATCH /Users/{userId}/status always 500s on current UAA: the
-		// updateAccountStatus handler in ScimUserEndpoints.java is missing
-		// @ResponseBody (accidentally dropped in cloudfoundry/uaa commit
-		// 6159e2f4, 2016), so Spring tries to resolve an HTML view instead
-		// of returning JSON. Reproduced against a freshly-booted UAA, not
-		// suite/state-dependent. Un-pend once fixed upstream.
+	It("unlocks the user", func() {
 		runOK("unlock-user", username)
 	})
 })


### PR DESCRIPTION
GitHub's changelog: as of 2026-07-14, Dependabot applies a default 3-day cooldown to all version updates.
- Don't require cooldown for our own go-uaa
- Bump go-uaa
- Bump go version to 1.26, 1.25 is EOL
- Unpend integration tests for list-clients and unlock-user. now that we have latest go-uaa and bug is fixed in uaa